### PR TITLE
Cambios principales en la migración de Javalin 6 → 7:    - En Javalin 7 todas las rutas deben registrarse en Javalin.create(config -> {})      antes de llamar a start(); los métodos app.get()/before()/etc. ya no existen      en la clase Javalin.    - BaseControlador ahora recibe JavalinConfig en lugar de Javalin; cada controlador      registra sus rutas via config.routes.get(), config.routes.before(), etc.    - config.router.apiBuilder() → config.routes.apiBuilder()    - RouteOverviewPlugin → config.bundledPlugins.enableRouteOverview("/routes")    - Validators requieren .required().get() para mantener el comportamiento no-nulo de v6    - javalin-rendering separado en módulos por motor: javalin-rendering-thymeleaf/freemarker/velocity    - StaticFileConfig.precompress eliminado en v7    - ZonaAdminClasica: patrón del before actualizado a "/zona-admin-clasica/*

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 # El comando FROM indica la imagen base.
 # openjdk:11.0.7-jre-slim-buster es una imagen de Java 11 lo mas ligera posible
-FROM eclipse-temurin:21-jre-noble
+FROM eclipse-temurin:25-jre-noble
 
 # Quien mantiene la versión.
 LABEL maintainer="Carlos Camacho <ca.camacho@ce.pucmm.edu.do>"

--- a/README.md
+++ b/README.md
@@ -1,24 +1,298 @@
-# Proyecto Demostración Sobre Javalin
+# Proyecto Demostración — Javalin 7
 
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/vacax/javalin-demo)
 
-Proyecto demostración de los conceptos:
+Proyecto de demostración de conceptos de desarrollo web con **Javalin 7.2.2** y **Java 25**.
+Orientado a estudiantes que están comenzando a desarrollar aplicaciones web,
+aprendiendo el protocolo HTTP, HTML, CSS y JavaScript.
 
-* Protocolo HTTP
-* Comunicación entre peticiones
-* Websockets
-* Plantillas
-* Cookies y Sesiones
-* Seguridad
-* Servicios Web SOAP
-* Servicios REST
-* Heroku
- 
-## Guía de pruebas
- <<TODO...>>
- 
-## Requiere:
+---
 
-* Java 21
-* Gradle 8.5
-* Javalin 6.1.3
+## Requisitos
+
+| Herramienta | Versión |
+|-------------|---------|
+| Java        | 25      |
+| Gradle      | 9.5.1 (usa el wrapper `./gradlew`) |
+| Javalin     | 7.2.2   |
+
+---
+
+## Cómo ejecutar
+
+```bash
+# Compilar y ejecutar en modo desarrollo (puerto 7000)
+./gradlew run
+
+# Generar el fat-jar (para despliegue)
+./gradlew shadowJar
+java -jar build/libs/app.jar
+
+# Con Docker
+./gradlew shadowJar
+docker build -t javalin-demo .
+docker run -p 7000:7000 javalin-demo
+```
+
+El servidor queda disponible en **http://localhost:7000**
+
+Para ver todas las rutas registradas visita: **http://localhost:7000/routes**
+
+---
+
+## Conceptos demostrados
+
+### 1. Protocolo HTTP básico — `/isc415`
+
+Demuestra los **verbos HTTP**, los manejadores `before`/`after` y cómo leer y escribir cabeceras.
+
+| Acción | Ejemplo |
+|--------|---------|
+| Ver el ciclo before → handler → after | `GET http://localhost:7000/isc415` |
+| Enviar cabecera personalizada | Agrega `-H "profesor: Juan"` a la petición |
+| Probar otros verbos | POST, PUT, DELETE, PATCH sobre `/isc415` |
+
+```bash
+# GET — responde con el método y la variable de contexto inyectada por before
+curl http://localhost:7000/isc415
+
+# POST con cabecera personalizada
+curl -X POST -H "profesor: Juan" http://localhost:7000/isc415
+
+# Listar todos los headers que el cliente envía
+curl http://localhost:7000/leerheaders
+```
+
+---
+
+### 2. Recepción de datos
+
+#### Query parameters
+```bash
+# Parámetros en la URL (?clave=valor)
+curl "http://localhost:7000/parametros?matricula=20011136&nombre=Carlos"
+```
+
+#### Path parameters
+```bash
+# Parámetro dentro de la URL
+curl http://localhost:7000/parametros/20011136/
+
+# Varios parámetros combinados
+curl http://localhost:7000/parametros/20011136/nombre/Carlos
+```
+
+#### Form data (body)
+Abre en el navegador: **http://localhost:7000/formulario.html**
+O envíalo con curl:
+```bash
+curl -X POST -d "matricula=20011136&nombre=Carlos&carrera=ISC" \
+     http://localhost:7000/parametros
+```
+
+---
+
+### 3. Cookies y Sesiones
+
+Las **cookies** se almacenan en el navegador del cliente.
+Las **sesiones** se almacenan en el servidor y se identifican por un ID en una cookie.
+
+```bash
+# Crear una cookie con tiempo de vida de 120 segundos
+curl -c cookies.txt http://localhost:7000/crearCookie/nombre/Carlos
+
+# Ver las cookies guardadas en el cliente
+curl -b cookies.txt http://localhost:7000/listarCookies
+
+# Contador de sesión (incrementa con cada visita — usar el navegador para ver el efecto)
+curl -c session.txt -b session.txt http://localhost:7000/contadorSesion
+
+# Invalidar la sesión
+curl -c session.txt -b session.txt http://localhost:7000/invalidarSesion
+```
+
+**Formulario de login con cookies:** http://localhost:7000/formulario_cookie.html
+
+---
+
+### 4. Autenticación clásica con sesión — `/zona-admin-clasica/`
+
+Muestra cómo proteger rutas verificando si existe un usuario en la sesión HTTP.
+El filtro `before` redirige a `/401.html` si no hay sesión activa.
+
+```
+1. Abrir http://localhost:7000/login.html
+2. Ingresar usuario: cualquiera / contraseña: cualquiera  (FakeServices siempre autentica)
+3. Acceder a http://localhost:7000/zona-admin-clasica/
+```
+
+> **Concepto de seguridad:** Ver `PruebaRoboSesion.java` para entender
+> cómo un atacante podría robar una sesión activa.
+
+---
+
+### 5. Excepciones y códigos de error HTTP
+
+```bash
+# 404 Not Found
+curl -i http://localhost:7000/excepciones/ruta-no-encontrada
+
+# 401 Unauthorized
+curl -i http://localhost:7000/excepciones/ruta-sin-permisos
+
+# Error 500 capturado por el handler de excepciones
+curl http://localhost:7000/excepciones/provocando-error
+
+# Ruta que no existe (manejada por el error 404 personalizado)
+curl -H "Accept: text/html" http://localhost:7000/ruta-inexistente
+```
+
+---
+
+### 6. Plantillas de servidor (Server-Side Rendering)
+
+Tres motores de plantillas para generar HTML dinámicamente en el servidor.
+
+| Motor      | Extensión | URL de ejemplo |
+|------------|-----------|----------------|
+| Thymeleaf  | `.html`   | http://localhost:7000/thymeleaf |
+| FreeMarker | `.ftl`    | http://localhost:7000/freemarker/datosEstudiante/20011136 |
+| Velocity   | `.vm`     | http://localhost:7000/velocity |
+
+Las plantillas se ubican en `src/main/resources/templates/`.
+
+---
+
+### 7. CRUD Tradicional (Thymeleaf + sesión)
+
+CRUD completo de estudiantes usando el patrón petición-respuesta clásico
+(sin JavaScript, el formulario envía datos al servidor que responde con una nueva página HTML).
+
+```
+http://localhost:7000/crud-simple/listar
+```
+
+Operaciones disponibles: Listar → Crear → Visualizar → Editar → Eliminar.
+
+> Los datos se almacenan en memoria (`FakeServices`); se pierden al reiniciar el servidor.
+
+---
+
+### 8. API REST — `/api/estudiante`
+
+Servicio REST para el manejo de estudiantes. Usa JSON como formato de intercambio.
+
+```bash
+# Listar todos los estudiantes
+curl http://localhost:7000/api/estudiante
+
+# Obtener un estudiante por matrícula
+curl http://localhost:7000/api/estudiante/20011136
+
+# Crear un estudiante
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"matricula":20011200,"nombre":"Ana López","carrera":"ISC"}' \
+     http://localhost:7000/api/estudiante
+
+# Actualizar un estudiante (enviar el objeto completo)
+curl -X PUT -H "Content-Type: application/json" \
+     -d '{"matricula":20011200,"nombre":"Ana María López","carrera":"ITT"}' \
+     http://localhost:7000/api/estudiante
+
+# Eliminar un estudiante
+curl -X DELETE http://localhost:7000/api/estudiante/20011200
+```
+
+---
+
+### 9. Control de acceso basado en roles — `/zona-admin-role`
+
+Demuestra RBAC (Role-Based Access Control). Cada endpoint declara qué roles pueden accederlo.
+El filtro `beforeMatched` verifica que el usuario en sesión tenga el rol requerido.
+
+**Usuarios precargados** (en `FakeServices`):
+
+| Usuario    | Contraseña | Roles                              |
+|------------|------------|------------------------------------|
+| `admin`    | `1234`      | ROLE_ADMIN, LOGUEADO, CUALQUIERA   |
+| `logueado` | `logueado`  | CUALQUIERA                         |
+| `usuario`  | `usuario`   | ROLE_USUARIO                       |
+
+```
+1. Autenticarse en http://localhost:7000/login.html  (usuario: admin, contraseña: 1234)
+2. Probar los endpoints:
+   http://localhost:7000/zona-admin-role           → requiere LOGUEADO
+   http://localhost:7000/zona-admin-role/admin     → requiere ROLE_ADMIN
+   http://localhost:7000/zona-admin-role/cliente   → requiere ROLE_USUARIO
+   http://localhost:7000/zona-admin-role/otro-rol  → cualquier rol
+```
+
+---
+
+### 10. Ejemplos HTML5 avanzados
+
+Páginas de demostración de APIs del navegador (sin frameworks).
+
+| Demo | URL |
+|------|-----|
+| Web Storage (localStorage/sessionStorage) | http://localhost:7000/html5/ejemploWebStorage.html |
+| IndexedDB | http://localhost:7000/html5/ejemploIndexedDb.html |
+| Geolocalización | http://localhost:7000/html5/ejemploGeoLocalizacion.html |
+| File API | http://localhost:7000/html5/ejemploArchivosApi.html |
+| Web Workers | http://localhost:7000/html5/ejemploWorker.html |
+| Service Worker / Offline | http://localhost:7000/html5/EjemploSinConexion.html |
+| Índice completo | http://localhost:7000/html5/index.html |
+
+El endpoint `/fecha` devuelve la hora del servidor y es consumido por los ejemplos de
+Web Workers con AJAX: **http://localhost:7000/fecha**
+
+---
+
+## Estructura del proyecto
+
+```
+src/main/java/edu/pucmm/eict/
+├── Main.java                          ← Punto de entrada; configura Javalin
+├── controladores/
+│   ├── ApiControlador.java            ← Handlers estáticos para /api/estudiante
+│   ├── ConceptoBasicosControlador.java← Verbos HTTP, before/after, cabeceras
+│   ├── CookiesSesionesControlador.java← Cookies, sesiones, autenticación
+│   ├── CrudTradicionalControlador.java← CRUD con plantillas Thymeleaf
+│   ├── ExcepcionesControlador.java    ← Manejo de excepciones y errores HTTP
+│   ├── PlantillasControlador.java     ← Thymeleaf, FreeMarker, Velocity
+│   ├── ZonaAdminClasica.java          ← Auth clásica con sesión
+│   └── ZonaAdminConRoles.java         ← RBAC con RouteRole
+├── encapsulaciones/
+│   ├── Estudiante.java                ← POJO
+│   └── Usuario.java                   ← POJO con roles
+├── servicios/
+│   └── FakeServices.java              ← Singleton con datos en memoria
+└── util/
+    ├── BaseControlador.java           ← Clase base (recibe JavalinConfig)
+    ├── NoExisteEstudianteException.java
+    ├── PruebaRoboSesion.java          ← Demo de robo de sesión con Jsoup
+    └── RolesApp.java                  ← Enum de roles (implementa RouteRole)
+
+src/main/resources/
+├── publico/                           ← Archivos estáticos (HTML, CSS, JS)
+│   └── html5/                         ← Demos de APIs HTML5
+└── templates/                         ← Plantillas de servidor
+    ├── crud-tradicional/              ← Thymeleaf para el CRUD
+    ├── freemarker/                    ← Plantillas .ftl
+    ├── thymeleaf/                     ← Plantillas .html
+    └── velocity/                      ← Plantillas .vm
+```
+
+---
+
+## Diferencias clave frente a Javalin 6
+
+| Javalin 6 | Javalin 7 |
+|-----------|-----------|
+| `app.get()`, `app.before()`, etc. en cualquier momento | Rutas solo dentro de `Javalin.create(config -> {...})` |
+| `config.router.apiBuilder()` | `config.routes.apiBuilder()` |
+| `config.registerPlugin(new RouteOverviewPlugin())` | `config.bundledPlugins.enableRouteOverview("/routes")` |
+| `validator.get()` devuelve no-nulo | `validator.required().get()` para comportamiento equivalente |
+| `javalin-rendering` (un solo artefacto) | `javalin-rendering-thymeleaf`, `-freemarker`, `-velocity` |
+| `BaseControlador(Javalin app)` | `BaseControlador(JavalinConfig config)` |
+| Jetty 11 (`javax.servlet.*`) | Jetty 12 (`jakarta.servlet.*`) |

--- a/build.gradle
+++ b/build.gradle
@@ -1,65 +1,60 @@
 plugins {
     id 'java'
     id 'application'
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'com.gradleup.shadow' version '9.0.0'
 }
 
 group 'edu.pucmm.eict'
 version '1.0-SNAPSHOT'
 
 java {
-    sourceCompatibility = '21'
+    sourceCompatibility = '25'
+    targetCompatibility = '25'
 }
 
-mainClassName='edu.pucmm.eict.Main'
+application {
+    mainClass = 'edu.pucmm.eict.Main'
+}
 
 repositories {
     mavenCentral()
-    maven{
-        url "https://maven.reposilite.com/snapshots"
-    }
 }
 
 dependencies {
-    //Libreria test
+    // Test
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
-    //dependencia de Javalin
-    implementation 'io.javalin:javalin:6.1.3'
+    // Javalin 7
+    implementation 'io.javalin:javalin:7.2.2'
 
-    //manejo de log.
-    implementation("org.slf4j:slf4j-simple:2.0.10")
+    // Logging
+    implementation 'org.slf4j:slf4j-simple:2.0.10'
 
-    //libreria jsoup.
-    implementation group: 'org.jsoup', name: 'jsoup', version: '1.15.3'
+    // Jsoup
+    implementation 'org.jsoup:jsoup:1.15.3'
 
-    //Procesamiento JSON.
-    implementation("com.fasterxml.jackson.core:jackson-core:2.15.2")
-    implementation('com.fasterxml.jackson.core:jackson-databind:2.15.2')
-    implementation("com.fasterxml.jackson.core:jackson-annotations:2.15.2")
+    // JSON (Jackson)
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
 
-    // En la versión 5.3.X separaron las clases del renderizado en otro proyecto
-    implementation "io.javalin:javalin-rendering:6.1.3"
-
-    //sistemas de plantilla:
-    implementation 'org.freemarker:freemarker:2.3.32'
-    implementation 'org.thymeleaf:thymeleaf:3.1.1.RELEASE'
-    implementation 'org.apache.velocity:velocity-engine-core:2.3'
-
+    // Sistemas de plantilla: cada módulo empaqueta su propio motor
+    implementation 'io.javalin:javalin-rendering-thymeleaf:7.2.2'
+    implementation 'io.javalin:javalin-rendering-freemarker:7.2.2'
+    implementation 'io.javalin:javalin-rendering-velocity:7.2.2'
 }
 
-shadowJar{
-    archiveBaseName.set("app")
+shadowJar {
+    archiveBaseName.set('app')
     archiveClassifier.set('')
     archiveVersion.set('')
 }
 
 /**
- * tarea necesaria para heroku si optamos por la tarea de Shadowjar
- * en el archivo Procfile debe estar el siguiente comando:
- * web: java -jar build/libs/app.jar
+ * Tarea necesaria para Heroku: genera el fat-jar mediante shadowJar.
+ * En el Procfile debe estar: web: java -jar build/libs/app.jar
  */
-task stage {
+tasks.register('stage') {
     dependsOn shadowJar
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/edu/pucmm/eict/Main.java
+++ b/src/main/java/edu/pucmm/eict/Main.java
@@ -3,7 +3,6 @@ package edu.pucmm.eict;
 import edu.pucmm.eict.controladores.*;
 import io.javalin.Javalin;
 import io.javalin.http.staticfiles.Location;
-import io.javalin.plugin.bundled.RouteOverviewPlugin;
 import io.javalin.rendering.template.JavalinThymeleaf;
 
 import java.text.SimpleDateFormat;
@@ -13,30 +12,30 @@ import static io.javalin.apibuilder.ApiBuilder.*;
 
 public class Main {
 
-
     public static void main(String[] args) {
-        //Ejemplo hola mundo
-        String mensaje = "Hola Mundo en Javalin :-D";
-        System.out.println(mensaje);
+        System.out.println("Hola Mundo en Javalin 7 :-D");
 
-        //Creando la instancia del servidor y configurando.
-        Javalin app = Javalin.create(config ->{
-            //configurando los documentos estaticos.
+        /**
+         * En Javalin 7 TODAS las rutas y manejadores deben registrarse
+         * dentro del bloque Javalin.create() antes de llamar a start().
+         */
+        Javalin app = Javalin.create(config -> {
+
+            // Archivos estáticos servidos desde /publico en el classpath
             config.staticFiles.add(staticFileConfig -> {
                 staticFileConfig.hostedPath = "/";
                 staticFileConfig.directory = "/publico";
                 staticFileConfig.location = Location.CLASSPATH;
-                staticFileConfig.precompress=false;
-                staticFileConfig.aliasCheck=null;
+                staticFileConfig.aliasCheck = null;
             });
 
-            //Confifgurar el sistema de plantilla por defecto.
+            // Motor de plantillas por defecto: Thymeleaf (usado en /crud-simple y /thymeleaf)
             config.fileRenderer(new JavalinThymeleaf());
 
-            //
-            config.router.apiBuilder(() -> {
-                path("/api",() -> {
+            // Rutas del API REST (/api/estudiante) y CRUD tradicional (/crud-simple)
+            config.routes.apiBuilder(() -> {
 
+                path("/api", () -> {
                     path("/estudiante", () -> {
                         get(ApiControlador::listarEstudiantes);
                         post(ApiControlador::crearEstudiante);
@@ -46,79 +45,74 @@ public class Main {
                             delete(ApiControlador::eliminarEstudiante);
                         });
                     });
-
                 });
 
                 /**
-                 * Las clases que implementan el sistema de plantilla están agregadas en PlantillasControlador.
+                 * CRUD con plantillas Thymeleaf (flujo petición-respuesta tradicional).
                  * http://localhost:7000/crud-simple/listar
                  */
                 path("/crud-simple/", () -> {
-                    get(ctx -> {
-                        ctx.redirect("/crud-simple/listar");
-                    });
-                    get("/listar",CrudTradicionalControlador::listar);
-                    get("/crear",CrudTradicionalControlador::crearEstudianteForm);
-                    post("/crear",CrudTradicionalControlador::procesarCreacionEstudiante);
-                    get("/visualizar/{matricula}",CrudTradicionalControlador::visualizarEstudiante);
-                    get("/editar/{matricula}",CrudTradicionalControlador::editarEstudianteForm);
-                    post("/editar",CrudTradicionalControlador::procesarEditarEstudiante);
-                    get("/eliminar/{matricula}",CrudTradicionalControlador::eliminarEstudiante);
+                    get(ctx -> ctx.redirect("/crud-simple/listar"));
+                    get("/listar", CrudTradicionalControlador::listar);
+                    get("/crear", CrudTradicionalControlador::crearEstudianteForm);
+                    post("/crear", CrudTradicionalControlador::procesarCreacionEstudiante);
+                    get("/visualizar/{matricula}", CrudTradicionalControlador::visualizarEstudiante);
+                    get("/editar/{matricula}", CrudTradicionalControlador::editarEstudianteForm);
+                    post("/editar", CrudTradicionalControlador::procesarEditarEstudiante);
+                    get("/eliminar/{matricula}", CrudTradicionalControlador::eliminarEstudiante);
                 });
-
             });
 
-            config.registerPlugin(new RouteOverviewPlugin());
+            // Endpoint raíz
+            config.routes.get("/", ctx -> ctx.result("Hola Mundo en Javalin 7 :-D"));
+
+            // Endpoint auxiliar para los ejemplos de HTML5 (lee la hora del servidor)
+            config.routes.get("/fecha", ctx ->
+                ctx.result(new SimpleDateFormat("dd/MM/yyyy HH:mm:ss").format(new Date()))
+            );
+
+            // Header requerido por los navegadores para Service Workers servidos desde el classpath
+            config.routes.after(ctx -> {
+                if (ctx.path().equalsIgnoreCase("/serviceworkers.js")) {
+                    ctx.header("Content-Type", "application/javascript");
+                    ctx.header("Service-Worker-Allowed", "/");
+                }
+            });
+
+            // Conceptos básicos del protocolo HTTP (before, after, verbos, cabeceras)
+            new ConceptoBasicosControlador(config).aplicarRutas();
+
+            // Recepción de datos: query params, path params, body form-data
+            new RecibirDatosControlador(config).aplicarRutas();
+
+            // Cookies y sesiones HTTP
+            new CookiesSesionesControlador(config).aplicarRutas();
+
+            // Zona protegida con sesión (autenticación clásica sin roles)
+            new ZonaAdminClasica(config).aplicarRutas();
+
+            // Manejo de excepciones y códigos de error HTTP
+            new ExcepcionesControlador(config).aplicarRutas();
+
+            // Plantillas: Thymeleaf, FreeMarker y Velocity
+            new PlantillasControlador(config).aplicarRutas();
+
+            // Zona protegida con roles (RBAC)
+            new ZonaAdminConRoles(config).aplicarRutas();
+
+            // Resumen visual de todas las rutas registradas → http://localhost:7000/routes
+            config.bundledPlugins.enableRouteOverview("/routes");
+
         });
 
-        //
         app.start(getHerokuAssignedPort());
-
-        //creando el manejador
-        app.get("/", ctx -> ctx.result("Hola Mundo en Javalin :-D"));
-
-        //aplicando los diferentes conceptos.
-        new ConceptoBasicosControlador(app).aplicarRutas();
-        //aplicando las rutas para el procesamiento de los datos.
-        new RecibirDatosControlador(app).aplicarRutas();
-        //ejemplos de cookies y sesiones.
-        new CookiesSesionesControlador(app).aplicarRutas();
-        //ejemplo de manejo de sesiones y seguridad clasica.
-        new ZonaAdminClasica(app).aplicarRutas();
-        //manejo de codigo de errores y excepciones
-        new ExcepcionesControlador(app).aplicarRutas();
-        //Manejo de plantillas.
-        new PlantillasControlador(app).aplicarRutas();
-        //Concepto de seguridad con roles.
-        new ZonaAdminConRoles(app).aplicarRutas();
-
-        //Endpoint ejemplos html5.
-        app.get("/fecha", ctx -> {
-            ctx.result(""+new SimpleDateFormat("dd/MM/yyyy HH:mm:ss").format(new Date()));
-        });
-
-        //Filtro para enviar el header de validación
-        app.after(ctx -> {
-            if(ctx.path().equalsIgnoreCase("/serviceworkers.js")){
-                System.out.println("Enviando el header de seguridad para el Service Worker");
-                ctx.header("Content-Type","application/javascript");
-                ctx.header("Service-Worker-Allowed", "/");
-            }
-
-        });
-
     }
 
     /**
-     * Metodo para indicar el puerto en Heroku
-     * @return
+     * Devuelve el puerto asignado por Heroku o 7000 en desarrollo local.
      */
     static int getHerokuAssignedPort() {
-        ProcessBuilder processBuilder = new ProcessBuilder();
-        if (processBuilder.environment().get("PORT") != null) {
-            return Integer.parseInt(processBuilder.environment().get("PORT"));
-        }
-        return 7000; //Retorna el puerto por defecto en caso de no estar en Heroku.
+        String port = new ProcessBuilder().environment().get("PORT");
+        return port != null ? Integer.parseInt(port) : 7000;
     }
-
 }

--- a/src/main/java/edu/pucmm/eict/controladores/ApiControlador.java
+++ b/src/main/java/edu/pucmm/eict/controladores/ApiControlador.java
@@ -2,16 +2,9 @@ package edu.pucmm.eict.controladores;
 
 import edu.pucmm.eict.encapsulaciones.Estudiante;
 import edu.pucmm.eict.servicios.FakeServices;
-import edu.pucmm.eict.util.BaseControlador;
-import edu.pucmm.eict.util.NoExisteEstudianteException;
-import io.javalin.Javalin;
-import io.javalin.apibuilder.EndpointGroup;
 import io.javalin.http.Context;
 import io.javalin.http.NotFoundResponse;
 import org.jetbrains.annotations.NotNull;
-
-
-import static io.javalin.apibuilder.ApiBuilder.*;
 
 public class ApiControlador  {
 
@@ -23,7 +16,7 @@ public class ApiControlador  {
     }
 
     public static void estudiantePorMatricula(@NotNull Context ctx) throws Exception {
-        Estudiante es = fakeServices.getEstudiantePorMatricula(ctx.pathParamAsClass("matricula", Integer.class).get());
+        Estudiante es = fakeServices.getEstudiantePorMatricula(ctx.pathParamAsClass("matricula", Integer.class).required().get());
 
         if(es!=null){
             ctx.json(es);
@@ -48,7 +41,7 @@ public class ApiControlador  {
 
     public static void eliminarEstudiante(@NotNull Context ctx) throws Exception {
         //parseando la informacion del POJO debe venir en formato json.
-        ctx.json(fakeServices.eliminandoEstudiante(ctx.pathParamAsClass("matricula", Integer.class).get()));
+        ctx.json(fakeServices.eliminandoEstudiante(ctx.pathParamAsClass("matricula", Integer.class).required().get()));
     }
 
 

--- a/src/main/java/edu/pucmm/eict/controladores/ConceptoBasicosControlador.java
+++ b/src/main/java/edu/pucmm/eict/controladores/ConceptoBasicosControlador.java
@@ -1,120 +1,113 @@
 package edu.pucmm.eict.controladores;
 
-import io.javalin.Javalin;
+import io.javalin.config.JavalinConfig;
 import io.javalin.http.Context;
 
+/**
+ * Demuestra los conceptos básicos del protocolo HTTP:
+ * manejadores before/after, los distintos verbos HTTP y cómo leer
+ * y escribir cabeceras en la trama de petición/respuesta.
+ */
 public class ConceptoBasicosControlador {
 
-    private Javalin app;
+    private final JavalinConfig config;
 
-    public ConceptoBasicosControlador(Javalin app){
-        this.app = app;
+    public ConceptoBasicosControlador(JavalinConfig config) {
+        this.config = config;
     }
 
-    public void aplicarRutas(){
+    public void aplicarRutas() {
+
         /**
-         * Manejador que se aplica todas las llamadas que sean realizada.
-         * Notar la ausencia del path.
+         * Manejador before que se aplica a TODAS las llamadas.
+         * Se ejecuta antes del handler del endpoint.
          */
-        app.before(ctxContextContext -> {
-            //
-            String mensaje = String.format("Manejador before aplicando a todas las llamadas: %s, Contexto: %s, Metodo: %s",
-                    ctxContextContext.req().getRemoteHost(),
-                    ctxContextContext.path(),
-                    ctxContextContext.req().getMethod());
-            //
+        config.routes.before(ctx -> {
+            String mensaje = String.format(
+                "Manejador before (global): host=%s, path=%s, método=%s",
+                ctx.req().getRemoteHost(),
+                ctx.path(),
+                ctx.req().getMethod()
+            );
             System.out.println(mensaje);
         });
 
         /**
-         * Manejador que se aplica de la ruta /isc415
+         * Manejador before acotado al path /isc415.
+         * Permite establecer variables de contexto para el endpoint.
          */
-        app.before("/isc415", ctxContextContext -> {
-            //
-            String mensaje = String.format("Manejador before aplicando en el Contexto: %s, Metodo: %s",
-                    ctxContextContext.req().getRequestURI(),
-                    ctxContextContext.req().getMethod());
-            //aplicando cambios o validaciones.
-            ctxContextContext.attribute("mi-variable", "Hola Mundo"); //variable en el contexto de petición
-            //
+        config.routes.before("/isc415", ctx -> {
+            String mensaje = String.format(
+                "Manejador before (/isc415): uri=%s, método=%s",
+                ctx.req().getRequestURI(),
+                ctx.req().getMethod()
+            );
+            ctx.attribute("mi-variable", "Hola Mundo"); // variable disponible en el handler
             System.out.println(mensaje);
         });
 
         /**
-         * Handler sobre el endpoint, en al variable ctxContext.
+         * Handler GET para /isc415.
+         * Demuestra cómo leer/escribir cabeceras HTTP y el método del request.
+         * http://localhost:7000/isc415
          */
-        app.get("/isc415", ctxContextContext -> {
-            String metodo = ctxContextContext.req().getMethod(); //la información del encapsulada del cliente.
-            metodo = ctxContextContext.method().name();
-            ctxContextContext.res().setHeader("asignatura", "ISC-415");
-            ctxContextContext.header("otro-header", "Mi header enviado");
-            //La forma utilizando HttpServletResponse
-            /*PrintWriter printWriter = new PrintWriter(ctxContext.res.getOutputStream());
-            printWriter.println("Endpoint "+ctxContext.req.getRequestURI()+" -  Metodo: "+metodo);
-            printWriter.flush();
-            printWriter.close();*/
-            ctxContextContext.result("Endpoint "+ctxContextContext.req().getRequestURI()+" -  Metodo: "+metodo+" - Variable: "+ctxContextContext.attribute("mi-variable"));
+        config.routes.get("/isc415", ctx -> {
+            String metodo = ctx.method().name();
+            ctx.res().setHeader("asignatura", "ISC-415");
+            ctx.header("otro-header", "Mi header enviado");
+            ctx.result("Endpoint " + ctx.req().getRequestURI()
+                + " - Método: " + metodo
+                + " - Variable: " + ctx.attribute("mi-variable"));
         });
 
         /**
-         * Handler despues de cualquier llamada, siempre que no exista un error.
-         * nota la ausencia de path
+         * Manejador after para TODAS las llamadas.
+         * Se ejecuta después del handler del endpoint.
          */
-        app.after(ctxContextContext -> {
-            String mensaje = String.format("Handler after para cualquier llamada - Usuario: %s, Contexto: %s",
-                    ctxContextContext.req().getRemoteHost(),
-                    ctxContextContext.contextPath()
-                    );
+        config.routes.after(ctx -> {
+            String mensaje = String.format(
+                "Handler after (global): host=%s, contextPath=%s",
+                ctx.req().getRemoteHost(),
+                ctx.contextPath()
+            );
             System.out.println(mensaje);
         });
 
         /**
-         * Aplica luego de la respuesta del endpoint del contexto /isc415
+         * Manejador after acotado al path /isc415.
          */
-        app.after("/isc415", ctxContext -> {
-            //
-            String mensaje = String.format("Manejador after aplicando en el Contexto: %s, Metodo: %s",
-                    ctxContext.req().getRequestURI(),
-                    ctxContext.req().getMethod());
-            //aplicando cambios o validaciones.
-            ctxContext.header("incluido-after","fue ejecutando en bloque after");
-            //ctxContext.header("nombre"); ctxContext.req.getHeader("nombre") desde el cliente.
-            //ctxContext.header("otro-header", ctxContext.res.getHeader("otro-header").toUpperCase()+" - Incluir otra cosa....");
-            //
+        config.routes.after("/isc415", ctx -> {
+            String mensaje = String.format(
+                "Manejador after (/isc415): uri=%s, método=%s",
+                ctx.req().getRequestURI(),
+                ctx.req().getMethod()
+            );
+            ctx.header("incluido-after", "fue ejecutando en bloque after");
             System.out.println(mensaje);
         });
 
         /**
-         * la ruta (path) puede ser la misma siempre y cuando el verbo cambie.
-         * Ver los diferentes ejemplos.
+         * Los diferentes verbos HTTP pueden compartir el mismo path.
+         * Prueba con: POST, PUT, DELETE, OPTIONS, PATCH, HEAD en /isc415
          */
-        app.post("/isc415",this::procesamiento);
-
-        app.put("/isc415", this::procesamiento);
-
-        app.delete("/isc415", this::procesamiento);
-
-        app.options("/isc415", this::procesamiento);
-
-        app.patch("/isc415", this::procesamiento);
-
-        app.head("/isc415", this::procesamiento);
+        config.routes.post("/isc415", this::procesamiento);
+        config.routes.put("/isc415", this::procesamiento);
+        config.routes.delete("/isc415", this::procesamiento);
+        config.routes.options("/isc415", this::procesamiento);
+        config.routes.patch("/isc415", this::procesamiento);
+        config.routes.head("/isc415", this::procesamiento);
 
         /**
-         * bloque retornar el mimetype del archivo para el cache.
+         * Devuelve el MIME type correcto para el manifiesto de caché del ejemplo de Service Worker.
          */
-        app.after("/html5/sinconexion.appcache", ctxContext -> {
-            System.out.println("Llamando el cache....");
-            ctxContext.contentType("text/cache-manifest");
+        config.routes.after("/html5/sinconexion.appcache", ctx -> {
+            System.out.println("Enviando cabecera del manifiesto de caché...");
+            ctx.contentType("text/cache-manifest");
         });
-
     }
 
-    /**
-     *
-     * @param ctxContext
-     */
-    private void procesamiento(Context ctxContext){
-        ctxContext.result("Trabajando por el metodo: "+ctxContext.method()+" - Header[profesor] = "+ctxContext.header("profesor"));
+    private void procesamiento(Context ctx) {
+        ctx.result("Trabajando con el método: " + ctx.method()
+            + " - Header[profesor] = " + ctx.header("profesor"));
     }
 }

--- a/src/main/java/edu/pucmm/eict/controladores/CookiesSesionesControlador.java
+++ b/src/main/java/edu/pucmm/eict/controladores/CookiesSesionesControlador.java
@@ -3,137 +3,135 @@ package edu.pucmm.eict.controladores;
 import edu.pucmm.eict.encapsulaciones.Usuario;
 import edu.pucmm.eict.servicios.FakeServices;
 import edu.pucmm.eict.util.BaseControlador;
-import io.javalin.Javalin;
+import io.javalin.config.JavalinConfig;
 
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Demuestra el uso de cookies y sesiones HTTP:
+ * - Cookies: almacenamiento en el cliente con tiempo de expiración.
+ * - Sesiones: almacenamiento en el servidor asociado a un ID de sesión.
+ * - Autenticación simple con sesión.
+ */
 public class CookiesSesionesControlador extends BaseControlador {
 
     public static List<String> lista = new ArrayList<>();
 
-    public CookiesSesionesControlador(Javalin app) {
-        super(app);
+    public CookiesSesionesControlador(JavalinConfig config) {
+        super(config);
     }
 
     @Override
     public void aplicarRutas() {
 
         /**
-         * La creación de la cookie es un proceso indicando en la trama de respuesta del servidor
-         * en el cliente, en el objeto response, Javalin simplifica con un método directo.
+         * Crea una cookie en el navegador del cliente con tiempo de vida de 120 segundos.
          * http://localhost:7000/crearCookie/micookie/valor-de-la-cookie
          */
-        app.get("/crearCookie/{nombre}/{valor}", ctxContext -> {
-            //creando una cookie para dos minutos, el parametro indicando en segundos.
-            //ctx.res.addCookie(new Cookie("key", "valor"));
-            ctxContext.cookie(ctxContext.pathParam("nombre"), ctxContext.pathParam("valor"), 120);
-            ctxContext.cookie("usuario", "CarlosCamacho", 120);
-            ctxContext.result("Cookie creada...");
+        config.routes.get("/crearCookie/{nombre}/{valor}", ctx -> {
+            ctx.cookie(ctx.pathParam("nombre"), ctx.pathParam("valor"), 120);
+            ctx.cookie("usuario", "CarlosCamacho", 120);
+            ctx.result("Cookie creada...");
         });
 
         /**
-         * Listando todas las cookies almacenadas en el cliente para el servidor
-         * que nos encontramos.
+         * Lista todas las cookies almacenadas en el cliente para este servidor.
          * http://localhost:7000/listarCookies
          */
-        app.get("/listarCookies", ctxContext -> {
+        config.routes.get("/listarCookies", ctx -> {
             List<String> salida = new ArrayList<>();
-            salida.add("Mostrando las cookies generadas en el cliente:");
-            //listando la informacion.
-            ctxContext.cookieMap().forEach((key, valor) -> {
-                salida.add(String.format("[%s] = [%s]", key, String.join(",", valor)));
-            });
-            //
-            if(ctxContext.cookie("usuario")!=null){
-                salida.add("Hola "+ctxContext.cookie("usuario"));
-            }else{
-                salida.add("No envio la información");
+            salida.add("Cookies del cliente:");
+            ctx.cookieMap().forEach((key, valor) ->
+                salida.add(String.format("[%s] = [%s]", key, String.join(",", valor)))
+            );
+            if (ctx.cookie("usuario") != null) {
+                salida.add("Hola " + ctx.cookie("usuario"));
+            } else {
+                salida.add("No se envió la cookie 'usuario'");
             }
-            //
-            ctxContext.result(String.join("\n", salida));
+            ctx.result(String.join("\n", salida));
         });
 
         /**
-         *
+         * Login usando cookies para mantener la identidad del usuario.
+         * Formulario en: http://localhost:7000/formulario_cookie.html
          */
-        app.post("/login-cookies", ctxContext -> {
-            //recibiendo información del formulario.
-            String usuario = ctxContext.formParam("usuario");
-            String contrasena = ctxContext.formParam("contrasena");
-            if(usuario==null || contrasena == null){
-                //errror para procesar la información.
-                ctxContext.redirect("/formulario_cookie.html");
+        config.routes.post("/login-cookies", ctx -> {
+            String usuario = ctx.formParam("usuario");
+            String contrasena = ctx.formParam("contrasena");
+            if (usuario == null || contrasena == null) {
+                ctx.redirect("/formulario_cookie.html");
                 return;
             }
-            //Estamos haciendo fake de un servicio de autenticacion, busque en un servicio.
-            ctxContext.cookie("usuario", usuario, 120);
-            ctxContext.cookie("nombre", "Nombre%20de%20Usuario%20"+usuario, 120);
-            //enviando a la vista.
-            ctxContext.redirect("/inicio-cookie");
+            ctx.cookie("usuario", usuario, 120);
+            ctx.cookie("nombre", "Nombre%20de%20Usuario%20" + usuario, 120);
+            ctx.redirect("/inicio-cookie");
         });
 
         /**
-         *
-         *
+         * Página de inicio protegida por cookie.
+         * Redirige al formulario si la cookie no existe.
          */
-        app.get("/inicio-cookie", ctxContext -> {
-            if(ctxContext.cookie("nombre") == null || ctxContext.cookie("usuario")== null){//no ha realizado el proceso de login.
-                ctxContext.redirect("/formulario_cookie.html");
+        config.routes.get("/inicio-cookie", ctx -> {
+            if (ctx.cookie("nombre") == null || ctx.cookie("usuario") == null) {
+                ctx.redirect("/formulario_cookie.html");
                 return;
             }
-            ctxContext.result("Hola "+ctxContext.cookie("nombre")+", gracias por su visita!");
+            ctx.result("Hola " + ctx.cookie("nombre") + ", gracias por su visita!");
         });
 
         /**
-         * Creando una variable de sesion en el servidor asociado al usuario.
+         * Contador de visitas usando sesión del servidor.
+         * Cada recarga incrementa el contador; el valor persiste en la sesión.
          * http://localhost:7000/contadorSesion
          */
-        app.get("/contadorSesion", ctxContext -> {
-            //ctx.req.getSession().setAttribute("key", "valor"); // HTTPSession.
-            Integer contador = ctxContext.sessionAttribute("contador");
-            if(contador==null){
-                contador = 0;
-            }
+        config.routes.get("/contadorSesion", ctx -> {
+            Integer contador = ctx.sessionAttribute("contador");
+            if (contador == null) contador = 0;
             contador++;
-            ctxContext.sessionAttribute("contador", contador);
-            //
-            ctxContext.result(String.format("Usted a visitado esta pagina %d, sesion ID #%s", contador, ctxContext.req().getSession().getId()));
+            ctx.sessionAttribute("contador", contador);
+            ctx.result(String.format(
+                "Usted ha visitado esta página %d veces. Sesión ID: #%s",
+                contador,
+                ctx.req().getSession().getId()
+            ));
         });
 
         /**
-         * Invalidando la sesion, todos los objetos almacenados son eliminados.
+         * Invalida la sesión del servidor, eliminando todos sus atributos.
          * http://localhost:7000/invalidarSesion
          */
-        app.get("/invalidarSesion", ctxContext -> {
-            String id = ctxContext.req().getSession().getId();
-            //invalidando la sesion.
-            ctxContext.req().getSession().invalidate();
-            ctxContext.result(String.format("Sesion con ID: %s fue invalidada", id));
+        config.routes.get("/invalidarSesion", ctx -> {
+            String id = ctx.req().getSession().getId();
+            ctx.req().getSession().invalidate();
+            ctx.result("Sesión con ID: " + id + " fue invalidada");
         });
 
         /**
-         * Ejemplo de como autenticar utilizando sesiones.
+         * Autenticación con sesión: guarda el usuario en la sesión para
+         * que otros manejadores puedan verificar si está autenticado.
+         * Formulario en: http://localhost:7000/login.html
          */
-        app.post("/autenticar", ctxContext -> {
-            //Obteniendo la informacion de la petion. Pendiente validar los parametros.
-            String nombreUsuario = ctxContext.formParam("usuario");
-            String password = ctxContext.formParam("password");
-            //Autenticando el usuario para nuestro ejemplo siempre da una respuesta correcta.
+        config.routes.post("/autenticar", ctx -> {
+            String nombreUsuario = ctx.formParam("usuario");
+            String password = ctx.formParam("password");
             Usuario usuario = FakeServices.getInstancia().autheticarUsuario(nombreUsuario, password);
-            //agregando el usuario en la session... se puede validar si existe para solicitar el cambio.-
-            ctxContext.sessionAttribute("usuario", usuario);
-            //redireccionando la vista con autorizacion.
-            ctxContext.redirect("/zona-admin-clasica/");
+            ctx.sessionAttribute("usuario", usuario);
+            ctx.redirect("/zona-admin-clasica/");
         });
 
-        app.get("/contexto", ctxContext -> {
-            ctxContext.req().setAttribute("variable-request", "valor"); //se mantiene hasta la respuesta del servidor.
-            ctxContext.sessionAttribute("variable-sesion", "....."); //asociado a la cookie sesion que crea el servidor. 30 min.
-            //aplicación del referencia del objeto de clase o de instancia que tenga acceso.
-            lista.add("asasd");
-
+        /**
+         * Muestra los tres tipos de almacenamiento de estado en HTTP:
+         * - Atributo de request (dura solo la petición actual)
+         * - Atributo de sesión (persiste en la sesión, ~30 min)
+         * - Variable de aplicación (estática, dura mientras corre la JVM)
+         */
+        config.routes.get("/contexto", ctx -> {
+            ctx.req().setAttribute("variable-request", "valor");
+            ctx.sessionAttribute("variable-sesion", ".....");
+            lista.add("elemento de aplicación");
+            ctx.result("Ver los distintos ámbitos (scopes) en el log del servidor.");
         });
-
     }
 }

--- a/src/main/java/edu/pucmm/eict/controladores/CrudTradicionalControlador.java
+++ b/src/main/java/edu/pucmm/eict/controladores/CrudTradicionalControlador.java
@@ -2,16 +2,12 @@ package edu.pucmm.eict.controladores;
 
 import edu.pucmm.eict.encapsulaciones.Estudiante;
 import edu.pucmm.eict.servicios.FakeServices;
-import edu.pucmm.eict.util.BaseControlador;
-import io.javalin.Javalin;
 import io.javalin.http.Context;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static io.javalin.apibuilder.ApiBuilder.*;
 
 /**
  * Representa las rutas para manejar las operaciones de petición - respuesta.
@@ -43,7 +39,7 @@ public class CrudTradicionalControlador  {
 
     public static void procesarCreacionEstudiante(@NotNull Context ctx) throws Exception {
         //obteniendo la información enviada.
-        int matricula = ctx.formParamAsClass("matricula", Integer.class).get();
+        int matricula = ctx.formParamAsClass("matricula", Integer.class).required().get();
         String nombre = ctx.formParam("nombre");
         String carrera = ctx.formParam("carrera");
         //
@@ -54,7 +50,7 @@ public class CrudTradicionalControlador  {
     }
 
     public static void visualizarEstudiante(@NotNull Context ctx) throws Exception {
-        Estudiante estudiante = fakeServices.getEstudiantePorMatricula(ctx.pathParamAsClass("matricula", Integer.class).get());
+        Estudiante estudiante = fakeServices.getEstudiantePorMatricula(ctx.pathParamAsClass("matricula", Integer.class).required().get());
         //
         Map<String, Object> modelo = new HashMap<>();
         modelo.put("titulo", "Formulario Visaulizar Estudiante "+estudiante.getMatricula());
@@ -67,7 +63,7 @@ public class CrudTradicionalControlador  {
     }
 
     public static void editarEstudianteForm(@NotNull Context ctx) throws Exception {
-        Estudiante estudiante = fakeServices.getEstudiantePorMatricula(ctx.pathParamAsClass("matricula", Integer.class).get());
+        Estudiante estudiante = fakeServices.getEstudiantePorMatricula(ctx.pathParamAsClass("matricula", Integer.class).required().get());
         //
         Map<String, Object> modelo = new HashMap<>();
         modelo.put("titulo", "Formulario Editar Estudiante "+estudiante.getMatricula());
@@ -80,7 +76,7 @@ public class CrudTradicionalControlador  {
 
     public static void procesarEditarEstudiante(@NotNull Context ctx) throws Exception {
         //obteniendo la información enviada.
-        int matricula = ctx.formParamAsClass("matricula", Integer.class).get();
+        int matricula = ctx.formParamAsClass("matricula", Integer.class).required().get();
         String nombre = ctx.formParam("nombre");
         String carrera = ctx.formParam("carrera");
         //
@@ -91,7 +87,7 @@ public class CrudTradicionalControlador  {
     }
 
     public static void eliminarEstudiante(@NotNull Context ctx) throws Exception {
-        fakeServices.eliminandoEstudiante(ctx.pathParamAsClass("matricula", Integer.class).get());
+        fakeServices.eliminandoEstudiante(ctx.pathParamAsClass("matricula", Integer.class).required().get());
         ctx.redirect("/crud-simple/");
     }
 

--- a/src/main/java/edu/pucmm/eict/controladores/ExcepcionesControlador.java
+++ b/src/main/java/edu/pucmm/eict/controladores/ExcepcionesControlador.java
@@ -1,53 +1,55 @@
 package edu.pucmm.eict.controladores;
 
 import edu.pucmm.eict.util.BaseControlador;
-import io.javalin.Javalin;
+import io.javalin.config.JavalinConfig;
 import io.javalin.http.NotFoundResponse;
 import io.javalin.http.UnauthorizedResponse;
 
+/**
+ * Demuestra el manejo de excepciones y códigos de error HTTP en Javalin.
+ * Referencia de códigos HTTP: https://developer.mozilla.org/es/docs/Web/HTTP/Status
+ */
 public class ExcepcionesControlador extends BaseControlador {
 
-    public ExcepcionesControlador(Javalin app) {
-        super(app);
+    public ExcepcionesControlador(JavalinConfig config) {
+        super(config);
     }
 
     @Override
     public void aplicarRutas() {
 
-        /**
-         * Javalin implementa respuestas automatica según el el codigo del protocolo HTTP
-         * que deseos tabajar: https://developer.mozilla.org/es/docs/Web/HTTP/Status
-         */
-        // ver el listado completo en:
-        // https://javalin.io/documentation#default-responses
-        // ir a http://localhost:7000/excepciones/ruta-no-encontrada
-        app.get("/excepciones/ruta-no-encontrada", ctx -> {
+        // Lanza una excepción 404 Not Found
+        // http://localhost:7000/excepciones/ruta-no-encontrada
+        config.routes.get("/excepciones/ruta-no-encontrada", ctx -> {
             throw new NotFoundResponse();
         });
 
-        // ir a http://localhost:7000/excepciones/ruta-sin-permisos
-        app.get("/excepciones/ruta-sin-permisos", ctx -> {
+        // Lanza una excepción 401 Unauthorized
+        // http://localhost:7000/excepciones/ruta-sin-permisos
+        config.routes.get("/excepciones/ruta-sin-permisos", ctx -> {
             throw new UnauthorizedResponse();
         });
 
-        //ir a http://localhost:7000/excepciones/provocando-error
-        app.get("/excepciones/provocando-error", ctx -> {
-            ctx.result("Error: "+Integer.parseInt("gagdagsd"));
-        });
-
-
-        /**
-         * Para el manejo de excepciones y codigo de errores
-         */
-        app.exception(NumberFormatException.class, (exception, ctx) -> {
-            ctx.html("Ocurrió un error en la conversacion numerica: "+exception.getLocalizedMessage());
-        });
+        // Provoca un NumberFormatException que es capturado por el handler de excepciones
+        // http://localhost:7000/excepciones/provocando-error
+        config.routes.get("/excepciones/provocando-error", ctx ->
+            ctx.result("Error: " + Integer.parseInt("texto-invalido"))
+        );
 
         /**
-         * Solo aplica cuando venga para vistas html.
+         * Manejador global de NumberFormatException.
+         * Intercepta cualquier NumberFormatException lanzada en cualquier endpoint.
          */
-        app.error(404,"text/html", ctx -> {
-            ctx.html("<h1>Recurso consultado no existe... Favor verificar...</h1>");
-        });
+        config.routes.exception(NumberFormatException.class, (exception, ctx) ->
+            ctx.html("Ocurrió un error en la conversión numérica: " + exception.getLocalizedMessage())
+        );
+
+        /**
+         * Manejador de error 404 para respuestas HTML.
+         * Solo se activa cuando el cliente acepta text/html.
+         */
+        config.routes.error(404, "text/html", ctx ->
+            ctx.html("<h1>El recurso consultado no existe. Favor verificar la URL.</h1>")
+        );
     }
 }

--- a/src/main/java/edu/pucmm/eict/controladores/PlantillasControlador.java
+++ b/src/main/java/edu/pucmm/eict/controladores/PlantillasControlador.java
@@ -1,11 +1,8 @@
 package edu.pucmm.eict.controladores;
 
 import edu.pucmm.eict.encapsulaciones.Estudiante;
-import edu.pucmm.eict.encapsulaciones.Usuario;
 import edu.pucmm.eict.util.BaseControlador;
-import io.javalin.Javalin;
-
-
+import io.javalin.config.JavalinConfig;
 import io.javalin.http.ContentType;
 import io.javalin.rendering.template.JavalinFreemarker;
 import io.javalin.rendering.template.JavalinVelocity;
@@ -16,84 +13,72 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-
-
+/**
+ * Demuestra el uso de los tres motores de plantillas incluidos:
+ * - Thymeleaf (motor por defecto, configurado en Main)
+ * - FreeMarker (.ftl)
+ * - Velocity (.vm)
+ */
 public class PlantillasControlador extends BaseControlador {
 
-    public PlantillasControlador(Javalin app) {
-        super(app);
-
+    public PlantillasControlador(JavalinConfig config) {
+        super(config);
     }
 
     @Override
     public void aplicarRutas() {
 
         /**
-         * Cada sistema de plantilla incluye etiquetas y tiene su forma de trabajo:
-         * ir a https://www.thymeleaf.org/doc/tutorials/3.0/usingthymeleaf.html
-         * http://localhost:7000/thymeleaf/
+         * Ejemplo con Thymeleaf (motor por defecto configurado en Main).
+         * Documentación: https://www.thymeleaf.org/doc/tutorials/3.0/usingthymeleaf.html
+         * http://localhost:7000/thymeleaf
          */
-        app.get("/thymeleaf", ctx -> {
-            List<Estudiante> listaEstudiante = getEstudiantes();
-
+        config.routes.get("/thymeleaf", ctx -> {
             Map<String, Object> modelo = new HashMap<>();
             modelo.put("titulo", "Ejemplo de funcionalidad Thymeleaf");
-            modelo.put("listaEstudiante", listaEstudiante);
-
-            //
+            modelo.put("listaEstudiante", getEstudiantes());
             ctx.render("/templates/thymeleaf/funcionalidad.html", modelo);
         });
 
         /**
-         * Cada sistema de plantilla incluye etiquetas y tiene su forma de trabajo:
-         * ir a https://freemarker.apache.org/docs/dgui.html
-         * Validando el sistema de plantilla
-         * Ir a: http://localhost:7000/freemarker/datosEstudiante/20011136
+         * Ejemplo con FreeMarker.
+         * Documentación: https://freemarker.apache.org/docs/dgui.html
+         * http://localhost:7000/freemarker/datosEstudiante/20011136
          */
-        app.get("/freemarker/datosEstudiante/{matricula}", ctx -> {
-            //tomando el parametro utl y validando el tipo.
-            int matricula = ctx.pathParamAsClass("matricula", Integer.class).get();
-            Estudiante estudiante = new Estudiante(matricula, "Estudiante matricula: "+matricula, "ISC");
-            //
+        config.routes.get("/freemarker/datosEstudiante/{matricula}", ctx -> {
+            int matricula = ctx.pathParamAsClass("matricula", Integer.class).required().get();
+            Estudiante estudiante = new Estudiante(matricula, "Estudiante matrícula: " + matricula, "ISC");
+
             Map<String, Object> modelo = new HashMap<>();
             modelo.put("estudiante", estudiante);
 
-            // enviando al sistema de plantilla para este caso con FreeMarker
             var render = new JavalinFreemarker();
             ctx.contentType(ContentType.HTML);
             ctx.result(render.render("/templates/freemarker/datosEstudiante.ftl", modelo, ctx));
         });
 
-
         /**
-         * Cada sistema de plantilla incluye etiquetas y tiene su forma de trabajo:
-         * ir a https://velocity.apache.org/engine/2.2/user-guide.html
-         * http://localhost:7000/velocity/
+         * Ejemplo con Apache Velocity.
+         * Documentación: https://velocity.apache.org/engine/2.2/user-guide.html
+         * http://localhost:7000/velocity
          */
-        app.get("/velocity", ctx -> {
-            //listando los estudiantes..
-            List<Estudiante> listaEstudiante = getEstudiantes();
-
+        config.routes.get("/velocity", ctx -> {
             Map<String, Object> modelo = new HashMap<>();
             modelo.put("titulo", "Ejemplo de funcionalidad Velocity");
-            modelo.put("listaEstudiante", listaEstudiante);
+            modelo.put("listaEstudiante", getEstudiantes());
 
-            // enviando al sistema de plantilla para este caso con FreeMarker
             var render = new JavalinVelocity();
             ctx.contentType(ContentType.HTML);
             ctx.result(render.render("/templates/velocity/funcionalidad.vm", modelo, ctx));
         });
-
-
     }
 
     @NotNull
     private List<Estudiante> getEstudiantes() {
-        //listando los estudiantes..
-        List<Estudiante> listaEstudiante = new ArrayList<>();
-        listaEstudiante.add(new Estudiante(20011136, "Carlos Camacho", "ITT"));
-        listaEstudiante.add(new Estudiante(20011137, "Otro Estudiante", "ISC"));
-        listaEstudiante.add(new Estudiante(20011138, "Otro otro", "ISC"));
-        return listaEstudiante;
+        List<Estudiante> lista = new ArrayList<>();
+        lista.add(new Estudiante(20011136, "Carlos Camacho", "ITT"));
+        lista.add(new Estudiante(20011137, "Otro Estudiante", "ISC"));
+        lista.add(new Estudiante(20011138, "Otro más", "ISC"));
+        return lista;
     }
 }

--- a/src/main/java/edu/pucmm/eict/controladores/RecibirDatosControlador.java
+++ b/src/main/java/edu/pucmm/eict/controladores/RecibirDatosControlador.java
@@ -1,90 +1,88 @@
 package edu.pucmm.eict.controladores;
 
 import edu.pucmm.eict.util.BaseControlador;
-import io.javalin.Javalin;
+import io.javalin.config.JavalinConfig;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Demuestra las distintas formas de recibir datos en una petición HTTP:
+ * query parameters, path parameters y body (form data).
+ */
 public class RecibirDatosControlador extends BaseControlador {
 
-    public RecibirDatosControlador(Javalin app) {
-        super(app);
+    public RecibirDatosControlador(JavalinConfig config) {
+        super(config);
     }
 
     @Override
     public void aplicarRutas() {
+
         /**
-         * Ejemplo para leer por parametros de consulta (query param)
+         * Parámetros de consulta (query params) en la URL.
          * http://localhost:7000/parametros?matricula=20011126&nombre=Carlos%20Camacho
          */
-        app.get("/parametros", ctx -> {
+        config.routes.get("/parametros", ctx -> {
             List<String> salida = new ArrayList<>();
-            salida.add("Mostrando todos los parametros enviados:");
-            //listando la informacion.
-            ctx.queryParamMap().forEach((key, lista) -> {
-                salida.add(String.format("[%s] = [%s]", key, String.join(",", lista)));
-            });
-            //
+            salida.add("Mostrando todos los parámetros enviados:");
+            ctx.queryParamMap().forEach((key, lista) ->
+                salida.add(String.format("[%s] = [%s]", key, String.join(",", lista)))
+            );
             ctx.result(String.join("\n", salida));
         });
 
         /**
-         * Ejemplo de parametros como parte de la URL, notar los ':' en el path.
+         * Parámetros como parte de la URL (path params).
          * http://localhost:7000/parametros/20011136/
          */
-        app.get("/parametros/{matricula}/", ctx -> {
-            //TODO: metodo para validar matricula..
-            ctx.result("El Estudiante tiene la matricula: "+ctx.pathParam("matricula"));
-        });
+        config.routes.get("/parametros/{matricula}/", ctx ->
+            ctx.result("El estudiante tiene la matrícula: " + ctx.pathParam("matricula"))
+        );
 
         /**
-         * Ejemplo de parametros como parte de la URL, notar los ':' en el path.
-         * Puedo hacer combinaciones
+         * Combinación de path params.
          * http://localhost:7000/parametros/20011136/nombre/carloscamacho
          */
-        app.get("/parametros/{matricula}/nombre/{nombre}", ctx -> {
-            ctx.result("El Estudiante tiene la matricula: "+ctx.pathParam("matricula")+" - nombre: "+ctx.pathParam("nombre"));
-        });
+        config.routes.get("/parametros/{matricula}/nombre/{nombre}", ctx ->
+            ctx.result("Matrícula: " + ctx.pathParam("matricula")
+                + " - Nombre: " + ctx.pathParam("nombre"))
+        );
 
-        app.get("/parametros/{para1}/{para2}/{para3}", ctx -> {
-            ctx.result("hhhhh");
-        });
+        config.routes.get("/parametros/{para1}/{para2}/{para3}", ctx ->
+            ctx.result("hhhhh")
+        );
 
-        //Llamada ambigua... puede que ejecute como que no.
-        app.get("/parametros/{para4}/{para5}/{para6}", ctx -> {
-            ctx.result("kkkkkk");
-        });
+        // Ruta ambigua: puede ejecutarse o no dependiendo del orden de registro
+        config.routes.get("/parametros/{para4}/{para5}/{para6}", ctx ->
+            ctx.result("kkkkkk")
+        );
 
         /**
-         * Ejemplo de información en el cuerpo del mensaje
-         * http://localhost:7000/formulario.html para el formulario
+         * Datos en el cuerpo del mensaje (body / form data).
+         * Utilizar el formulario en: http://localhost:7000/formulario.html
          */
-        app.post("/parametros", ctx -> {
-            System.out.println("El tipo de datos recibido: "+ctx.header("Content-Type")+ "Matricula:"+ctx.queryParam("matricula"));
+        config.routes.post("/parametros", ctx -> {
+            System.out.println("Content-Type: " + ctx.header("Content-Type")
+                + " - Matrícula (query): " + ctx.queryParam("matricula"));
             List<String> salida = new ArrayList<>();
-            salida.add("Mostrando todos la informacion enviada en el cuerpo:");
-            //listando la informacion.
-            ctx.formParamMap().forEach((key, lista) -> {
-                salida.add(String.format("[%s] = [%s]", key, String.join(",", lista)));
-            });
-            //
+            salida.add("Mostrando información enviada en el cuerpo:");
+            ctx.formParamMap().forEach((key, lista) ->
+                salida.add(String.format("[%s] = [%s]", key, String.join(",", lista)))
+            );
             ctx.result(String.join("\n", salida));
         });
 
         /**
-         * En cualquier situación puedo los encabezados de la trama HTTP.
+         * Leer todos los encabezados HTTP enviados por el cliente.
          * http://localhost:7000/leerheaders
          */
-        app.get("leerheaders", ctx -> {
+        config.routes.get("leerheaders", ctx -> {
             List<String> salida = new ArrayList<>();
-            salida.add("Mostrando la informacion enviada en los headers:");
-            //listando la informacion.
-            ctx.headerMap().forEach((key, valor) -> {
-                salida.add(String.format("[%s] = [%s]", key, String.join(",", valor)));
-            });
-            //
+            salida.add("Encabezados enviados en la trama HTTP:");
+            ctx.headerMap().forEach((key, valor) ->
+                salida.add(String.format("[%s] = [%s]", key, String.join(",", valor)))
+            );
             ctx.result(String.join("\n", salida));
         });
     }

--- a/src/main/java/edu/pucmm/eict/controladores/ZonaAdminClasica.java
+++ b/src/main/java/edu/pucmm/eict/controladores/ZonaAdminClasica.java
@@ -2,50 +2,46 @@ package edu.pucmm.eict.controladores;
 
 import edu.pucmm.eict.encapsulaciones.Usuario;
 import edu.pucmm.eict.util.BaseControlador;
-import io.javalin.Javalin;
+import io.javalin.config.JavalinConfig;
 
-
+/**
+ * Demuestra la protección de rutas mediante sesión HTTP (autenticación clásica sin roles).
+ * El filtro before verifica que exista un usuario en sesión antes de acceder a /zona-admin-clasica/.
+ *
+ * Las sesiones pueden ser vulnerables al robo de sesión:
+ * https://es.wikipedia.org/wiki/Secuestro_de_sesi%C3%B3n
+ * (ver también PruebaRoboSesion.java)
+ */
 public class ZonaAdminClasica extends BaseControlador {
 
-    public ZonaAdminClasica(Javalin app) {
-        super(app);
+    public ZonaAdminClasica(JavalinConfig config) {
+        super(config);
     }
 
     @Override
     public void aplicarRutas() {
 
         /**
-         * Ejemplo para agrupar path según su contexto, ejemplo.
-         * http://localhost:7000/zona-admin-clasica/
-         *
-         * Las sesiones pueden ser vulnerables por el robo se sesiones:
-         * https://es.wikipedia.org/wiki/Secuestro_de_sesi%C3%B3n
+         * Filtro before: intercepta todas las llamadas a /zona-admin-clasica/ y sub-rutas.
+         * Si no hay sesión activa, redirige a la página de error 401.
+         * Autenticarse primero en: http://localhost:7000/login.html
          */
-
-        /**
-         * Validando que exista el usuario por el filtro.
-         */
-        app.before("/zona-admin-clasica/", ctx -> {
-            //recuperando el usuario de la sesión,en caso de no estar, redirecciona la pagina 401.
+        config.routes.before("/zona-admin-clasica/*", ctx -> {
             Usuario usuario = ctx.sessionAttribute("usuario");
-            if(usuario == null){// usuario no existe
+            if (usuario == null) {
                 ctx.redirect("/401.html");
             }
-            //continuando con la consulta del endpoint solicitado.
         });
 
-        //Respuesta del index.
-        //http://localhost:7000/zona-admin-clasica/
-        app.get("/zona-admin-clasica/", ctx ->{
+        // http://localhost:7000/zona-admin-clasica/
+        config.routes.get("/zona-admin-clasica/", ctx -> {
             Usuario usuario = ctx.sessionAttribute("usuario");
-            ctx.result("Zona Admin por la forma clasica --- Usuario: "+usuario.getUsuario());
-        } );
-
-        //controlado por el filtro...
-        //http://localhost:7000/zona-admin-clasica/otro-zona/otra/
-        app.get("/zona-admin-clasica/otro-zona/otra/", ctx -> {
-            ctx.result("El filtro controla todas los path por debajo del grupo....");
+            ctx.result("Zona Admin (auth clásica) — Usuario: " + usuario.getUsuario());
         });
 
+        // http://localhost:7000/zona-admin-clasica/otro-zona/otra/
+        config.routes.get("/zona-admin-clasica/otro-zona/otra/", ctx ->
+            ctx.result("El filtro controla todas las rutas por debajo del prefijo...")
+        );
     }
 }

--- a/src/main/java/edu/pucmm/eict/controladores/ZonaAdminConRoles.java
+++ b/src/main/java/edu/pucmm/eict/controladores/ZonaAdminConRoles.java
@@ -4,94 +4,79 @@ import edu.pucmm.eict.encapsulaciones.Usuario;
 import edu.pucmm.eict.servicios.FakeServices;
 import edu.pucmm.eict.util.BaseControlador;
 import edu.pucmm.eict.util.RolesApp;
-import io.javalin.Javalin;
-import io.javalin.http.Handler;
+import io.javalin.config.JavalinConfig;
 import io.javalin.http.UnauthorizedResponse;
-import org.slf4j.Logger;
-
-import java.util.Collections;
-
-import static io.javalin.apibuilder.ApiBuilder.*;
 
 /**
- * Ejemplo de permisos basado en roles
+ * Demuestra el control de acceso basado en roles (RBAC) en Javalin 7.
+ * Cada endpoint declara los roles que pueden accedlo; el filtro beforeMatched
+ * verifica que el usuario autenticado tenga al menos uno de esos roles.
+ *
+ * Usuarios de prueba (ver FakeServices):
+ *  - admin   / 1234       → roles: ROLE_ADMIN, LOGUEADO, CUALQUIERA
+ *  - logueado / logueado  → roles: CUALQUIERA
+ *  - usuario  / usuario   → roles: ROLE_USUARIO
  */
 public class ZonaAdminConRoles extends BaseControlador {
 
-    FakeServices fakeServices = FakeServices.getInstancia();
+    private final FakeServices fakeServices = FakeServices.getInstancia();
 
-    public ZonaAdminConRoles(Javalin app) {
-        super(app);
+    public ZonaAdminConRoles(JavalinConfig config) {
+        super(config);
     }
 
     @Override
     public void aplicarRutas() {
 
-        /*
-         * Aplicando la configuracion para manejar los roles
+        /**
+         * beforeMatched se ejecuta solo cuando se encontró un endpoint que coincide.
+         * Verifica sesión y rol antes de dejar pasar la petición.
          */
-
-        app.beforeMatched("/zona-admin-role",ctx -> {
-            //Si el endpoint no tiene roles asignados no es necesario verificarlo.
-            if(ctx.routeRoles().isEmpty()){
-                return;
+        config.routes.beforeMatched("/zona-admin-role*", ctx -> {
+            if (ctx.routeRoles().isEmpty()) {
+                return; // endpoint sin roles declarados, acceso libre
             }
 
-            //para obtener el usuario estaré utilizando el contexto de sesion.
-            final Usuario usuario = ctx.sessionAttribute("usuario");
+            Usuario usuario = ctx.sessionAttribute("usuario");
             if (usuario == null) {
                 throw new UnauthorizedResponse();
             }
 
-            //listando los roles del endpoint.
-            System.out.println("Los roles asignados a la ruta: "+ctx.routeRoles());
+            System.out.println("Roles requeridos por la ruta: " + ctx.routeRoles());
 
-            //buscando el permiso del usuario.
             Usuario usuarioTmp = fakeServices.getListaUsuarios().stream()
                     .filter(u -> u.getUsuario().equalsIgnoreCase(usuario.getUsuario()))
                     .findAny()
-                    .orElse(null);
+                    .orElseThrow(() -> new UnauthorizedResponse("Usuario sin roles para acceder."));
 
-            if(usuarioTmp==null){
-                System.out.println("Existe el usuario pero sin roles para acceder.");
-                throw new UnauthorizedResponse("No tiene roles para acceder...");
+            System.out.println("Roles del usuario: " + usuarioTmp.getListaRoles());
+
+            boolean tienePermiso = usuarioTmp.getListaRoles().stream()
+                    .anyMatch(role -> ctx.routeRoles().contains(role));
+
+            if (!tienePermiso) {
+                throw new UnauthorizedResponse("No tiene el rol requerido para acceder.");
             }
-
-            System.out.println("Los roles asignados en el usuario: "+usuarioTmp.getListaRoles().toString());
-
-            //validando que el usuario registrando tiene el rol permitido.
-            boolean encontrado = false;
-            for(RolesApp role : usuarioTmp.getListaRoles() ) {
-                if (ctx.routeRoles().contains(role)) {
-                    System.out.println(String.format("El Usuario: %s - con el Rol: %s tiene permiso", usuarioTmp.getUsuario(), role.name()));
-                    encontrado = true;
-                    break;
-                }
-            }
-            //
-            if(!encontrado){
-                throw new UnauthorizedResponse("No tiene roles para acceder...");
-            }
-
         });
 
+        // Requiere estar autenticado (LOGUEADO). http://localhost:7000/zona-admin-role
+        config.routes.get("/zona-admin-role", ctx ->
+            ctx.result("Con permiso para acceder a la zona"), RolesApp.LOGUEADO
+        );
 
-        app.get("/zona-admin-role", (Handler) ctx -> {
-            ctx.result("Con permiso para acceder a la zona");
-        }, RolesApp.LOGUEADO);
+        // Solo administradores. http://localhost:7000/zona-admin-role/admin
+        config.routes.get("/zona-admin-role/admin", ctx ->
+            ctx.result("Debe ser administrador"), RolesApp.ROLE_ADMIN
+        );
 
-        app.get("/zona-admin-role/admin", (Handler) ctx -> {
-            ctx.result("Debe ser administrador");
-        }, RolesApp.ROLE_ADMIN);
+        // Solo usuarios con rol ROLE_USUARIO. http://localhost:7000/zona-admin-role/cliente
+        config.routes.get("/zona-admin-role/cliente", ctx ->
+            ctx.result("Debe ser cliente"), RolesApp.ROLE_USUARIO
+        );
 
-        app.get("/zona-admin-role/cliente", (Handler) ctx -> {
-            ctx.result("Debe ser cliente");
-        }, RolesApp.ROLE_USUARIO);
-
-        app.get("/zona-admin-role/otro-rol", (Handler) ctx -> {
-            ctx.result("otro cualquier rol");
-        }, RolesApp.CUALQUIERA);
-
-
+        // Cualquier rol declarado. http://localhost:7000/zona-admin-role/otro-rol
+        config.routes.get("/zona-admin-role/otro-rol", ctx ->
+            ctx.result("Cualquier rol definido puede acceder"), RolesApp.CUALQUIERA
+        );
     }
 }

--- a/src/main/java/edu/pucmm/eict/util/BaseControlador.java
+++ b/src/main/java/edu/pucmm/eict/util/BaseControlador.java
@@ -1,13 +1,18 @@
 package edu.pucmm.eict.util;
 
-import io.javalin.Javalin;
+import io.javalin.config.JavalinConfig;
 
+/**
+ * Clase base para todos los controladores del proyecto.
+ * En Javalin 7, el registro de rutas se realiza a través de JavalinConfig
+ * dentro del bloque Javalin.create(), por eso recibimos JavalinConfig.
+ */
 public abstract class BaseControlador {
 
-    protected Javalin app;
+    protected JavalinConfig config;
 
-    public BaseControlador(Javalin app){
-        this.app = app;
+    public BaseControlador(JavalinConfig config) {
+        this.config = config;
     }
 
     abstract public void aplicarRutas();


### PR DESCRIPTION
Migración de 6 a 7 